### PR TITLE
Revamp README and handle panic logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Zshs
+# Zshs 🌟
 
 Utility functions for Zsh uses.
 
-## Installation
+## Installation 📦
 
 - Requisites: Go 1.20
 
@@ -15,9 +15,9 @@ go install ./cmd/zshs
 
 Then it can be used anywhere by just typing `zshs`
 
-## Features
+## Features ✨
 
-### Search a plugin command
+### Search a plugin command 🔍
 I often found myself struggling to recall specific Zsh plugin commands. To avoid constantly referring to online cheat sheets, here is a search function:
 
 ```bash
@@ -25,12 +25,12 @@ zshs kubectl 'get pods'
 zshs git 'pull --rebase'
 ```
 
-## Checklist
+## Checklist ✅
 
 - [ ] Build CI
 - [ ] Make the first release
 
-## License
+## License 📜
 
 MIT License
 

--- a/cmd/zshs/main.go
+++ b/cmd/zshs/main.go
@@ -20,7 +20,8 @@ func main() {
 			keyword := ctx.Args().Get(1)
 			result, err := zshs.SearchPluginCommandHelp(plugin, keyword, os.Getenv("ZSH"))
 			if err != nil {
-				panic(err)
+				log.Fatal(err)
+				cli.ShowAppHelpAndExit(ctx, 1)
 			}
 
 			if len(result) > 0 {

--- a/package/zshs/plugin_util.go
+++ b/package/zshs/plugin_util.go
@@ -20,7 +20,7 @@ func SearchPluginCommandHelp(plugin string, keyword string, fromFolder string) (
 	plugins := fromFolder + pluginsFolder
 	dirs, err := os.ReadDir(plugins)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("error: %v", err)
 	}
 
 	var readmeFile string


### PR DESCRIPTION
Revamp the README to make it more impressive with emoji and handle panic logic to not panic but show command exit with error and display help.

* **README.md**
  - Add emoji to the title, installation, features, and checklist sections.
  - Update the title to "Zshs 🌟".
  - Add emoji to the installation section.
  - Add emoji to the features section.
  - Add emoji to the checklist section.

* **cmd/zshs/main.go**
  - Replace `panic(err)` with `log.Fatal(err)` in the `Action` function.
  - Add `cli.ShowAppHelpAndExit(ctx, 1)` to display help in the `Action` function.

* **package/zshs/plugin_util.go**
  - Replace `panic(err)` with `return nil, fmt.Errorf("error: %v", err)` in the `SearchPluginCommandHelp` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vuon9/zshs?shareId=4599c5d8-0458-449a-b7a4-b014c78bf476).