### PR TITLE
Add GH workflow to build and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.20
+
+    - name: Build
+      run: go build -v ./...
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.20
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.sha }}
+        release_name: Release ${{ github.sha }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./zshs
+        asset_name: zshs
+        asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ zshs kubectl 'get pods'
 zshs git 'pull --rebase'
 ```
 
-## Checklist ✅
-
-- [ ] Build CI
-- [ ] Make the first release
-
 ## License 📜
 
 MIT License


### PR DESCRIPTION
Add GitHub Actions workflow for CI/CD

* **Add CI workflow**: Create `.github/workflows/ci.yml` to build on new PRs and release on PR merges to master.
* **Update README**: Remove checklist items for "Build CI" and "Make the first release".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vuon9/zshs?shareId=508b5bbc-a5af-4ba3-9365-a9083b109f6d).