### PR TITLE
Make package/zshs to internal package

### DIFF
--- a/cmd/zshs/main.go
+++ b/cmd/zshs/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/urfave/cli/v2"
-	"github.com/vuon9/zshs/package/zshs"
+	"github.com/vuon9/zshs/internal/zshs"
 )
 
 func main() {


### PR DESCRIPTION
Move `plugins.go` from `package/zshs` to `internal/zshs`.

Update import path in `cmd/zshs/main.go`:
* Change import path from `github.com/vuon9/zshs/package/zshs` to `github.com/vuon9/zshs/internal/zshs`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vuon9/zshs?shareId=2c851a61-7990-439b-9a7c-0ad4d89c5884).